### PR TITLE
Here are some fixes / improvements for better stability and AMD / RequireJS support.

### DIFF
--- a/pttjpeg.js
+++ b/pttjpeg.js
@@ -1237,8 +1237,9 @@ var pttJPEG = (function namespace() {
 if( typeof exports != 'undefined' ) {
     exports.pttJPEG = pttJPEG;
 }
-try{
-    if ( typeof importScripts != 'undefined' ) {
+
+if ( typeof importScripts != 'undefined' ) {
+    try{
         var encoder = new pttJPEG();
         encoder.dlog("petitoJPEG WebWorker started");
         // inside a web worker context
@@ -1269,6 +1270,6 @@ try{
             postMessage(m);
 
         }
+    } catch (e) {
     }
-} catch (e) {
 }

--- a/pttjpeg.js
+++ b/pttjpeg.js
@@ -1268,7 +1268,12 @@
             }
         } catch (e) {
         }
-    } else if (typeof window != 'undefined') {                      //  Inside a regular web page.
+    } else if (typeof define != undefined && define.amd) {          //  Loaded with AMD /
+                                                                    //  RequireJS.
+        define([], function() { return PTTJPEG; });
+    } else if (typeof window != 'undefined') {                      //  Inside a regular web page,
+                                                                    //  and not loaded via AMD /
+                                                                    //  RequireJS.
         window.pttJPEG = PTTJPEG;
     }
 }());

--- a/pttjpeg.js
+++ b/pttjpeg.js
@@ -67,7 +67,11 @@ var pttJPEG = (function namespace() {
      *  string sprintf(string format , [mixed arg1 [, mixed arg2 [ ,...]]]);
      *
      */
-    var ct = typeof exports != "undefined" ? exports : typeof window!="undefined" ? window : self;
+    var ct = {};        //  This is a modification to the embedded sprintf.js logic so that it
+                        //  will attach itself to this object only.  This is so that the embedded
+                        //  version of sprintf.js does not get exported out into the global /
+                        //  application environment.
+
     (function(ctx) {
         var sprintf = function() {
             if (!sprintf.cache.hasOwnProperty(arguments[0])) {

--- a/pttjpeg.js
+++ b/pttjpeg.js
@@ -203,7 +203,7 @@ var pttJPEG = (function namespace() {
     var sprintf = ct.sprintf;  
 
     function DEBUGMSG(x) {
-        if( importScripts != 'undefined' ) {
+        if( typeof importScripts != 'undefined' ) {
             var m = {
                 'log' : x,
                 'reason' : 'log'

--- a/pttjpeg.js
+++ b/pttjpeg.js
@@ -1238,11 +1238,11 @@
         try{
             var encoder = new PTTJPEG();
             encoder.dlog("petitoJPEG WebWorker started");
+            encoder.dlog( encoder.version() );
             // inside a web worker context
             // see sender for image format
             onmessage = function( msg ) {
                 var encoder = new PTTJPEG();
-                encoder.dlog( encoder.version() );
                 encoder.dlog("petitoJPEG WebWorker: Got image "+  msg.data.width+"x"+msg.data.height );
                 msg.data.imageData.width = msg.data.width;
                 msg.data.imageData.height = msg.data.height;

--- a/pttjpeg.js
+++ b/pttjpeg.js
@@ -32,8 +32,37 @@ var pttJPEG = (function namespace() {
     // Debugging support
     //-------------------------------------------------------------------------------------------
 
-    /*! sprintf.js | Copyright (c) 2007-2013 Alexandru Marasteanu <hello at alexei dot ro> | 3 clause BSD license */
-    /* usage:
+    /*! sprintf.js
+     *
+     * Copyright (c) 2007-2014, Alexandru Marasteanu <hello [at) alexei (dot] ro>
+     * All rights reserved.
+     *
+     * Redistribution and use in source and binary forms, with or without
+     * modification, are permitted provided that the following conditions are met:
+     *
+     *     * Redistributions of source code must retain the above copyright
+     *       notice, this list of conditions and the following disclaimer.
+     *
+     *     * Redistributions in binary form must reproduce the above copyright
+     *       notice, this list of conditions and the following disclaimer in the
+     *       documentation and/or other materials provided with the distribution.
+     *
+     *     * Neither the name of this software nor the names of its contributors may be
+     *       used to endorse or promote products derived from this software without
+     *       specific prior written permission.
+     *
+     * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+     * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+     * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+     * DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+     * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+     * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+     * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+     * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+     * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+     * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+     *
+     * usage:
      *
      *  string sprintf(string format , [mixed arg1 [, mixed arg2 [ ,...]]]);
      *

--- a/pttjpeg.js
+++ b/pttjpeg.js
@@ -1267,6 +1267,7 @@
 
             }
         } catch (e) {
+            DEBUGMSG(sprintf("Caught exception: %s", e));
         }
     } else if (typeof define != undefined && define.amd) {          //  Loaded with AMD /
                                                                     //  RequireJS.

--- a/pttjpeg.js
+++ b/pttjpeg.js
@@ -206,7 +206,11 @@
     })(ct);
     var sprintf = ct.sprintf;  
 
+    var flagQuiet = false;
+
     function DEBUGMSG(x) {
+        if (flagQuiet) return;
+
         if( typeof importScripts != 'undefined' ) {
             var m = {
                 'log' : x,
@@ -1031,6 +1035,10 @@
         //--------------------------------------------------------------------
         // exported functions
         this.version = function() { return "petitóJPEG 0.3"; };
+
+        this.setVerbosity = function(flagVerbose) {
+            flagQuiet = !flagVerbose;
+        }
 
         this.ByteWriter = function() {
             var bufsize = 1024*1024*10;

--- a/pttjpeg.js
+++ b/pttjpeg.js
@@ -1234,9 +1234,9 @@ var pttJPEG = (function namespace() {
     return PTTJPEG; 
 }());
 
-if( typeof exports != 'undefined' ) {
+if( typeof exports != 'undefined' ) {                           //  Inside CommonJS / NodeJS.
     exports.pttJPEG = pttJPEG;
-} else if ( typeof importScripts != 'undefined' ) {
+} else if ( typeof importScripts != 'undefined' ) {             //  Inside an HTML5 web worker.
     try{
         var encoder = new pttJPEG();
         encoder.dlog("petitoJPEG WebWorker started");

--- a/pttjpeg.js
+++ b/pttjpeg.js
@@ -1228,46 +1228,43 @@ var pttJPEG = (function namespace() {
     }
 
 
+    if( typeof exports != 'undefined' ) {                           //  Inside CommonJS / NodeJS.
+        exports.pttJPEG = PTTJPEG;
+    } else if ( typeof importScripts != 'undefined' ) {             //  Inside an HTML5 web worker.
+        try{
+            var encoder = new PTTJPEG();
+            encoder.dlog("petitoJPEG WebWorker started");
+            // inside a web worker context
+            // see sender for image format
+            onmessage = function( msg ) {
+                var encoder = new PTTJPEG();
+                encoder.dlog( encoder.version() );
+                encoder.dlog("petitoJPEG WebWorker: Got image "+  msg.data.width+"x"+msg.data.height );
+                msg.data.imageData.width = msg.data.width;
+                msg.data.imageData.height = msg.data.height;
+                var inImg = new encoder.pttImage( msg.data.imageData );
+                var bw = new encoder.ByteWriter();
 
+                encoder.encode(msg.data.quality, inImg, bw);
 
+                var url = bw.getImgUrl();
+
+                var m = {
+                    'url' : url,
+                    'bw' : bw.getWrittenBytes(),
+                    'reason' : 'image',
+                    'width' : msg.data.width,
+                    'height' : msg.data.height,
+                    'quality' : msg.data.quality,
+                    'encodetime' : encoder.getEncodeTime()
+                }
+
+                postMessage(m);
+
+            }
+        } catch (e) {
+        }
+    }
 
     return PTTJPEG; 
 }());
-
-if( typeof exports != 'undefined' ) {                           //  Inside CommonJS / NodeJS.
-    exports.pttJPEG = pttJPEG;
-} else if ( typeof importScripts != 'undefined' ) {             //  Inside an HTML5 web worker.
-    try{
-        var encoder = new pttJPEG();
-        encoder.dlog("petitoJPEG WebWorker started");
-        // inside a web worker context
-        // see sender for image format
-        onmessage = function( msg ) {
-            var encoder = new pttJPEG();
-            encoder.dlog( encoder.version() );
-            encoder.dlog("petitoJPEG WebWorker: Got image "+  msg.data.width+"x"+msg.data.height );
-            msg.data.imageData.width = msg.data.width;
-            msg.data.imageData.height = msg.data.height;
-            var inImg = new encoder.pttImage( msg.data.imageData );
-            var bw = new encoder.ByteWriter();
-
-            encoder.encode(msg.data.quality, inImg, bw);
-
-            var url = bw.getImgUrl();
-
-            var m = {
-                'url' : url,
-                'bw' : bw.getWrittenBytes(),
-                'reason' : 'image',
-                'width' : msg.data.width,
-                'height' : msg.data.height,
-                'quality' : msg.data.quality,
-                'encodetime' : encoder.getEncodeTime()
-            }
-
-            postMessage(m);
-
-        }
-    } catch (e) {
-    }
-}

--- a/pttjpeg.js
+++ b/pttjpeg.js
@@ -1236,9 +1236,7 @@ var pttJPEG = (function namespace() {
 
 if( typeof exports != 'undefined' ) {
     exports.pttJPEG = pttJPEG;
-}
-
-if ( typeof importScripts != 'undefined' ) {
+} else if ( typeof importScripts != 'undefined' ) {
     try{
         var encoder = new pttJPEG();
         encoder.dlog("petitoJPEG WebWorker started");

--- a/pttjpeg.js
+++ b/pttjpeg.js
@@ -1238,7 +1238,7 @@ if( typeof exports != 'undefined' ) {
     exports.pttJPEG = pttJPEG;
 }
 try{
-    if (importScripts) {
+    if ( typeof importScripts != 'undefined' ) {
         var encoder = new pttJPEG();
         encoder.dlog("petitoJPEG WebWorker started");
         // inside a web worker context

--- a/pttjpeg.js
+++ b/pttjpeg.js
@@ -26,7 +26,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-var pttJPEG = (function namespace() {
+(function namespace() {
 
     //-------------------------------------------------------------------------------------------
     // Debugging support
@@ -1268,7 +1268,7 @@ var pttJPEG = (function namespace() {
             }
         } catch (e) {
         }
+    } else if (typeof window != 'undefined') {                      //  Inside a regular web page.
+        window.pttJPEG = PTTJPEG;
     }
-
-    return PTTJPEG; 
 }());


### PR DESCRIPTION
The list:
- Fully comply with sprintf.js license clause #1
- Preventing embedded sprintf.js from attaching itself to global namespace, avoiding interfering with potentially other versions of sprintf.js in the environment.
- Fixed global variable checks to avoid JavaScript undefined variable errors.
- Some syntax / logic cleanup, explanatory comments, etc.
- New feature: support for AMD / RequireJS.
- Modification: Setting the global variable pttJPEG only if the operating environment is a regular webpage and the logic is not loaded via AMD / RequireJS.  This is to separate the toolkit from the global namespace when loaded via AMD / RequireJS, and also not potentially interfere with other instances already loaded or to be loaded.
- Modification: Having the web worker send its version as soon as it starts.
- Modification: Having the web worker relay any exceptions it encounters.
- New feature: Allow user to disable log messages by calling new method 'setVerbosity(false)'.
